### PR TITLE
fix: fixed username link for public users

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ TCAS ranking algorithm. Feel free to open PR for improve my code.
 
 ## Authors
 
-[Nacnano](https://github.com/orgs/monkey-monkey/people/Nacnano)
+[Nacnano](https://github.com/Nacnano)
 
 ## License
 


### PR DESCRIPTION
Because public users can't access monkey-monkey repository

Yes, just a minor change